### PR TITLE
Fix import deprecation warning

### DIFF
--- a/caikit_tgis_backend/managed_tgis_subprocess.py
+++ b/caikit_tgis_backend/managed_tgis_subprocess.py
@@ -29,7 +29,7 @@ import grpc
 import requests
 
 # First Party
-from caikit.core.toolkit.errors import error_handler
+from caikit.core.exceptions import error_handler
 import alog
 
 # Local

--- a/caikit_tgis_backend/tgis_backend.py
+++ b/caikit_tgis_backend/tgis_backend.py
@@ -22,9 +22,9 @@ from typing import Dict, Optional
 import grpc
 
 # First Party
+from caikit.core.exceptions import error_handler
 from caikit.core.module_backends.backend_types import register_backend_type
 from caikit.core.module_backends.base import BackendBase
-from caikit.core.toolkit.errors import error_handler
 import alog
 
 # Local

--- a/caikit_tgis_backend/tgis_connection.py
+++ b/caikit_tgis_backend/tgis_connection.py
@@ -23,7 +23,7 @@ import shutil
 import grpc
 
 # First Party
-from caikit.core.toolkit.errors import error_handler
+from caikit.core.exceptions import error_handler
 import alog
 
 # Local


### PR DESCRIPTION
Since `caikit` [`v0.15`](https://github.com/caikit/caikit/releases/tag/v0.15.0), `error_handler` has been moved to `caikit.core.exceptions` (from `caikit.core.toolkit.errors  error_handler`).